### PR TITLE
Update commands so they work with FF 47

### DIFF
--- a/anim.mozcmd
+++ b/anim.mozcmd
@@ -23,8 +23,10 @@
     ],
     returnType: "string",
     exec: function(args, context) {
-      Services.prefs.setCharPref("image.animation_mode", args.mode);
-      return "Animation mode is set to '" + prefs.getCharPref(prefname) + "'";
+      let prefs = Components.classes["@mozilla.org/preferences-service;1"]
+                    .getService(Components.interfaces.nsIPrefService).getBranch("image.");
+      prefs.setCharPref("animation_mode", args.mode);
+      return "Animation mode is set to '" + prefs.getCharPref("animation_mode") + "'";
     }
   }
 ]

--- a/check-for-updates.mozcmd
+++ b/check-for-updates.mozcmd
@@ -10,7 +10,7 @@
 [
   {
     name: "chkupd",
-    description: "Check " + Application.name + " for updates.",
+    description: "Check for updates.",
     params: [
       {
         name: "option",
@@ -22,6 +22,7 @@
     ],
     returnType: "string",
     exec: function(args, context) {
+      var Cc = Components.classes; var Ci = Components.interfaces;
       function openURL(aURL) {
         let chromeWin = context.environment.chromeWindow ||
                         context.environment.chromeDocument.defaultView;

--- a/darken.mozcmd
+++ b/darken.mozcmd
@@ -19,6 +19,7 @@
   {
     name: "darken",
     description: "Darken content area.",
+    runAt: "client",
     params: [
       {
         name: "Dark level",

--- a/escape.mozcmd
+++ b/escape.mozcmd
@@ -21,6 +21,7 @@
     ],
     returnType: "string",
     exec: function(args, context) {
+      var Cc = Components.classes; var Ci = Components.interfaces;
       let contentWin = context.environment.window || context.environment.contentDocument.defaultView;
       let string = args.string;
       if (!string)
@@ -45,6 +46,7 @@
     ],
     returnType: "string",
     exec: function(args, context) {
+      var Cc = Components.classes; var Ci = Components.interfaces;
       let string = args.string;
       let unescaped = decodeURIComponent(string);
       let clipboardHelper = Cc["@mozilla.org/widget/clipboardhelper;1"].

--- a/jsenabled.mozcmd
+++ b/jsenabled.mozcmd
@@ -22,7 +22,8 @@
     exec: function(args, context) {
       let contentWin = context.environment.window || context.environment.contentDocument.defaultView;
       let prefname = "javascript.enabled";
-      let prefs = Services.prefs;
+      let prefs = Components.classes["@mozilla.org/preferences-service;1"]
+                        .getService(Components.interfaces.nsIPrefBranch);
       let jsEnabled = prefs.getBoolPref(prefname);
       prefs.setBoolPref(prefname, !jsEnabled);
       if (args.reload)

--- a/locale.mozcmd
+++ b/locale.mozcmd
@@ -30,7 +30,9 @@
         ---
         I couldn't find another way to change browser locale without using preferences
       */
-      let prefs = Services.prefs;
+      let prefs = Components.classes["@mozilla.org/preferences-service;1"]
+                        .getService(Components.interfaces.nsIPrefBranch);
+
       let msgPrefix = "Browser language: '";
       let msgSuffix = "'";
       let lang = args.langID;

--- a/tabsontop.mozcmd
+++ b/tabsontop.mozcmd
@@ -12,7 +12,8 @@
     name: "tabsontop",
     description: "Toggle Tabs on Top",
     exec: function(args, context) {
-      let prefs = Services.prefs;
+      let prefs = Components.classes["@mozilla.org/preferences-service;1"]
+                        .getService(Components.interfaces.nsIPrefBranch);
       let prefname = "browser.tabs.onTop";
       prefs.setBoolPref(prefname, !prefs.getBoolPref(prefname));
     }

--- a/view-source.mozcmd
+++ b/view-source.mozcmd
@@ -11,6 +11,7 @@
   {
     name: "vs",
     description: "View HTML source of current page or a specified URL.",
+    runAt: "client",
     params: [
       {
         name: "url",
@@ -41,7 +42,9 @@
   {
     name: "vrs",
     description: "View rendered source of current page.",
+    runAt: "client",
     exec: function(args, context) {
+      var Cc = Components.classes; var Ci = Components.interfaces;
       let environment = context.environment;
       let contentDoc = environment.document || environment.contentDocument;
       let chromeWin = environment.chromeWindow || environment.chromeDocument.defaultView;

--- a/whois.mozcmd
+++ b/whois.mozcmd
@@ -11,6 +11,7 @@
   {
     name: "whois",
     description: "Whois lookup using DomainTools web service.",
+    runAt: "client",
     params: [
       {
         name: "domain",
@@ -34,9 +35,11 @@
       if (!hostname) {
         return contentWin.location.protocol + " scheme is not supported.";
       }
+      var eTLDsvc = Components.classes["@mozilla.org/network/effective-tld-service;1"]
+                  .getService(Components.interfaces.nsIEffectiveTLDService);
 
-      let eTLDsvc = Services.eTLD;
-      let eTLD, URI = Services.io.newURI("http://" + hostname, null, null);
+      let eTLD, URI = Components.classes["@mozilla.org/network/io-service;1"]
+                .getService(Components.interfaces.nsIIOService).newURI("http://" + hostname, null, null);
       try {
         eTLD = eTLDsvc.getBaseDomain(URI);
       } catch (ex) {

--- a/winsize.mozcmd
+++ b/winsize.mozcmd
@@ -11,6 +11,7 @@
   {
     name: "winsize",
     description: "Resize browser window. If no parameters entered, display current window size.",
+    runAt: "client",
     params: [
       {
         name: "width",


### PR DESCRIPTION
chkupd (check-for-updates.mozcmd) does not seem to work any more and
tabsontop probably doesn't make any sense, now, with the new firefox theme.

Note: I have neither tested nor modified the extension part of the code.

PS Thank you for creating a repository of useful GCLI commands (one of the only ones on the internet)! 
